### PR TITLE
Add OIDC login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2024-01-10
+
+### Features
+
+- [**breaking**] Add OIDC login flow
+  - Previously available config options have been moved under the `jwt` key. See `README.md` for an example.
+
+### Miscellaneous Tasks
+
+- Add github action
+- Migrate to github
+
+### Refactoring
+
+- Appease linter
+- [**breaking**] Rename the 'require_expiracy' option to 'require_expiry'
+
 ## [0.3.2] - 2022-11-24
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ keyfile: path to asymetrical keyfile
 #algorithm: HS512
 # Allow registration of new users using these tokens, defaults to false
 #allow_registration: false
-# Require tokens to have an expiracy set, defaults to true
-#require_expiracy: true
+# Require tokens to have an expiry set, defaults to true
+#require_expiry: true
 ```
-It is recommended to have `require_expiracy` set to `true` (default). As for `allow_registration`, it depends on usecase: If you only want to be able to log in *existing* users, leave it at `false` (default). If nonexistant users should be simply registered upon hitting the login endpoint, set it to `true`.
+It is recommended to have `require_expiry` set to `true` (default). As for `allow_registration`, it depends on usecase: If you only want to be able to log in *existing* users, leave it at `false` (default). If nonexistant users should be simply registered upon hitting the login endpoint, set it to `true`.
 
 ## Usage
 First you have to generate a JWT with the correct claims. The `sub` claim is the localpart or full mxid of the user you want to log in as. Be sure that the algorithm and secret match those of the configuration. An example of the claims is as follows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = ["jwcrypto", "twisted"]
-version = "0.3.2"
+version = "0.4.0"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-token-authenticator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,13 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "mock",
-  "matrix-synapse"
+  "matrix-synapse",
+  "ruff",
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_token_authenticator --cov=tests"
 format = "black ."
+lint = "ruff check ."
 
 [tool.hatch.envs.ci.scripts]
 format = "black --check ."
@@ -54,8 +56,4 @@ parallel = true
 omit = []
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]

--- a/synapse_token_authenticator/config.py
+++ b/synapse_token_authenticator/config.py
@@ -1,0 +1,70 @@
+import os
+
+
+class TokenAuthenticatorConfig:
+    """
+    Parses and validates the provided config dictionary.
+    """
+
+    def __init__(self, other: dict):
+        if jwt := other.get("jwt"):
+
+            class JwtConfig:
+                def __init__(self, other: dict):
+                    self.secret: str | None = other.get("secret")
+                    self.keyfile: str | None = other.get("keyfile")
+
+                    self.algorithm: str = other.get("algorithm", "HS512")
+                    self.allow_registration: bool = other.get(
+                        "allow_registration", False
+                    )
+                    self.require_expiry: bool = other.get("require_expiry", True)
+
+            self.jwt = JwtConfig(jwt)
+            self.verify_jwt()
+
+        if oidc := other.get("oidc"):
+
+            class OIDCConfig:
+                def __init__(self, other: dict):
+                    try:
+                        self.issuer: str = other["issuer"]
+                        self.client_id: str = other["client_id"]
+                        self.client_secret: str = other["client_secret"]
+                        self.project_id: str = other["project_id"]
+                        self.organization_id: str = other["organization_id"]
+                    except KeyError as error:
+                        raise Exception(f"Config option must be set: {error.args[0]}")
+
+                    self.allowed_client_ids: str | None = other.get(
+                        "allowed_client_ids"
+                    )
+
+                    self.allow_registration: bool = other.get(
+                        "allow_registration", False
+                    )
+
+            self.oidc = OIDCConfig(oidc)
+
+    def verify_jwt(self):
+        if self.jwt.secret is None and self.jwt.keyfile is None:
+            raise Exception("Missing secret or keyfile")
+        if self.jwt.keyfile is not None and not os.path.exists(self.jwt.keyfile):
+            raise Exception("Keyfile doesn't exist")
+
+        if self.jwt.algorithm not in [
+            "HS256",
+            "HS384",
+            "HS512",
+            "RS256",
+            "RS384",
+            "RS512",
+            "ES256",
+            "ES384",
+            "ES512",
+            "PS256",
+            "PS384",
+            "PS512",
+            "EdDSA",
+        ]:
+            raise Exception(f"Unknown algorithm: '{self.jwt.algorithm}'")

--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Famedly
+# Copyright (C) 2024 Famedly
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -18,12 +18,20 @@ from typing import Awaitable, Callable, Optional, Tuple
 import logging
 from jwcrypto import jwt, jwk
 from jwcrypto.common import JWException, json_decode
-import os
+import json
 import base64
+import requests
+from requests.auth import HTTPBasicAuth
+from urllib.parse import urljoin
 
 import synapse
 from synapse.module_api import ModuleApi
 from synapse.types import UserID
+
+from twisted.web import resource
+
+from synapse_token_authenticator.config import TokenAuthenticatorConfig
+from synapse_token_authenticator.utils import OpenIDProviderMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -34,26 +42,57 @@ class TokenAuthenticator(object):
     def __init__(self, config: dict, account_handler: ModuleApi):
         self.api = account_handler
 
-        self.config = config
-        if self.config.secret:
-            k = {
-                "k": base64.urlsafe_b64encode(
-                    self.config.secret.encode("utf-8")
-                ).decode("utf-8"),
-                "kty": "oct",
-            }
-            self.key = jwk.JWK(**k)
-        else:
-            with open(self.config.keyfile, "r") as f:
-                self.key = jwk.JWK.from_pem(f.read())
+        auth_checkers = {}
 
-        self.api.register_password_auth_provider_callbacks(
-            auth_checkers={
-                ("com.famedly.login.token", ("token",)): self.check_auth,
-            },
-        )
+        self.config: TokenAuthenticatorConfig = config
+        if (jwt := getattr(self.config, "jwt", None)) is not None:
+            if jwt.secret:
+                k = {
+                    "k": base64.urlsafe_b64encode(jwt.secret.encode("utf-8")).decode(
+                        "utf-8"
+                    ),
+                    "kty": "oct",
+                }
+                self.key = jwk.JWK(**k)
+            else:
+                with open(jwt.keyfile, "r") as f:
+                    self.key = jwk.JWK.from_pem(f.read())
+            auth_checkers[("com.famedly.login.token", ("token",))] = self.check_jwt_auth
 
-    async def check_auth(
+        if (oidc := getattr(self.config, "oidc", None)) is not None:
+            auth_checkers[
+                ("com.famedly.login.token.oidc", ("token",))
+            ] = self.check_oidc_auth
+
+            self.api.register_web_resource(
+                "/_famedly/login/com.famedly.login.token.oidc",
+                self.LoginMetadataResource(oidc),
+            )
+
+        self.api.register_password_auth_provider_callbacks(auth_checkers=auth_checkers)
+
+    class LoginMetadataResource(resource.Resource):
+        def __init__(self, oidc_config: object):
+            self.issuer = oidc_config.issuer
+            self.metadata_url = urljoin(
+                oidc_config.issuer, "/.well-known/openid-configuration"
+            )
+            self.organization_id = oidc_config.organization_id
+            self.project_id = oidc_config.project_id
+
+        def render_GET(self, request):
+            request.setHeader(b"content-type", b"application/json")
+            request.setHeader(b"access-control-allow-origin", b"*")
+            return json.dumps(
+                {
+                    "issuer": self.issuer,
+                    "issuer-metadata": self.metadata_url,
+                    "organization-id": self.organization_id,
+                    "project-id": self.project_id,
+                }
+            ).encode("utf-8")
+
+    async def check_jwt_auth(
         self, username: str, login_type: str, login_dict: "synapse.module_api.JsonDict"
     ) -> Optional[
         Tuple[
@@ -71,7 +110,7 @@ class TokenAuthenticator(object):
         token = login_dict["token"]
 
         check_claims = {}
-        if self.config.require_expiry:
+        if self.config.jwt.require_expiry:
             check_claims["exp"] = None
         try:
             # OK, let's verify the token
@@ -79,7 +118,7 @@ class TokenAuthenticator(object):
                 jwt=token,
                 key=self.key,
                 check_claims=check_claims,
-                algs=[self.config.algorithm],
+                algs=[self.config.jwt.algorithm],
             )
         except ValueError as e:
             logger.info("Unrecognized token", e)
@@ -121,12 +160,12 @@ class TokenAuthenticator(object):
             return None
 
         user_exists = await self.api.check_user_exists(user_id_str)
-        if not user_exists and not self.config.allow_registration:
+        if not user_exists and not self.config.jwt.allow_registration:
             logger.info("User doesn't exist and registration is disabled")
             return None
 
         if not user_exists:
-            logger.info("User doesn't exist, registering it...")
+            logger.info("User doesn't exist, registering them...")
             await self.api.register_user(
                 user_id.localpart, admin=payload.get("admin", False)
             )
@@ -145,37 +184,90 @@ class TokenAuthenticator(object):
         logger.info("All done and valid, logging in!")
         return (user_id_str, None)
 
+    async def check_oidc_auth(
+        self, username: str, login_type: str, login_dict: "synapse.module_api.JsonDict"
+    ) -> Optional[
+        Tuple[
+            str,
+            Optional[Callable[["synapse.module_api.LoginResponse"], Awaitable[None]]],
+        ]
+    ]:
+        logger.info("Receiving auth request")
+        if login_type != "com.famedly.login.token.oidc":
+            logger.info("Wrong login type")
+            return None
+        if "token" not in login_dict:
+            logger.info("Missing token")
+            return None
+        token = login_dict["token"]
+
+        oidc = self.config.oidc
+        oidc_metadata = OpenIDProviderMetadata(oidc.issuer)
+
+        # Further validation using token introspection
+        data = {"token": token, "token_type_hint": "access_token", "scope": "openid"}
+        auth = HTTPBasicAuth(oidc.client_id, oidc.client_secret)
+        response = requests.post(
+            oidc_metadata.introspection_endpoint, data=data, auth=auth
+        )
+        if response.status_code == 401:
+            logger.info("User's access token is invalid")
+            return None
+
+        introspection_resp = response.json()
+
+        if not introspection_resp["active"]:
+            logger.info("User is not active")
+            return None
+
+        allowed_roles = ["User", "OrgAdmin"]
+
+        if not any(
+            [
+                role in allowed_roles
+                for role in introspection_resp[
+                    f"urn:zitadel:iam:org:project:{oidc.project_id}:roles"
+                ]
+            ]
+        ):
+            logger.info("User does not have a role in this project")
+            return None
+
+        if introspection_resp["iss"] != oidc_metadata.issuer:
+            logger.info(f"Token issuer does not match: {introspection_resp['iss']}")
+            return None
+
+        if (
+            oidc.allowed_client_ids is not None
+            and introspection_resp["client_id"] not in oidc.allowed_client_ids
+        ):
+            logger.info(
+                f"Client {introspection_resp['client_id']} is not in the list of allowed clients"
+            )
+            return None
+
+        # Checking if the user's localpart matches
+        user_id_str = self.api.get_qualified_user_id(username)
+        user_id = UserID.from_string(user_id_str)
+
+        if introspection_resp["localpart"] != user_id.localpart:
+            logger.info("The provided username is incorrect")
+            return None
+
+        user_exists = await self.api.check_user_exists(user_id_str)
+        if not user_exists and not self.config.oidc.allow_registration:
+            logger.info("User doesn't exist and registration is disabled")
+            return None
+
+        if not user_exists:
+            logger.info("User doesn't exist, registering it...")
+            await self.api.register_user(user_id.localpart)
+
+        user_id_str = self.api.get_qualified_user_id(username)
+
+        logger.info("All done and valid, logging in!")
+        return (user_id_str, None)
+
     @staticmethod
-    def parse_config(config):
-        class _TokenAuthenticatorConfig(object):
-            pass
-
-        _config = _TokenAuthenticatorConfig()
-        _config.secret = config.get("secret", False)
-        _config.keyfile = config.get("keyfile", False)
-        if not _config.secret and not _config.keyfile:
-            raise Exception("Missing secret or keyfile")
-        if _config.keyfile and not os.path.exists(_config.keyfile):
-            raise Exception("Keyfile doesn't exist")
-
-        _config.algorithm = config.get("algorithm", "HS512")
-        if _config.algorithm not in [
-            "HS256",
-            "HS384",
-            "HS512",
-            "RS256",
-            "RS384",
-            "RS512",
-            "ES256",
-            "ES384",
-            "ES512",
-            "PS256",
-            "PS384",
-            "PS512",
-            "EdDSA",
-        ]:
-            raise Exception("Unknown algorithm " + _config.algorithm)
-
-        _config.allow_registration = config.get("allow_registration", False)
-        _config.require_expiry = config.get("require_expiry", True)
-        return _config
+    def parse_config(config: dict):
+        return TokenAuthenticatorConfig(config)

--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -71,7 +71,7 @@ class TokenAuthenticator(object):
         token = login_dict["token"]
 
         check_claims = {}
-        if self.config.require_expiracy:
+        if self.config.require_expiry:
             check_claims["exp"] = None
         try:
             # OK, let's verify the token
@@ -177,5 +177,5 @@ class TokenAuthenticator(object):
             raise Exception("Unknown algorithm " + _config.algorithm)
 
         _config.allow_registration = config.get("allow_registration", False)
-        _config.require_expiracy = config.get("require_expiracy", True)
+        _config.require_expiry = config.get("require_expiry", True)
         return _config

--- a/synapse_token_authenticator/utils.py
+++ b/synapse_token_authenticator/utils.py
@@ -1,0 +1,31 @@
+import requests
+from urllib.parse import urljoin
+from jwcrypto.jwk import JWKSet
+
+
+class OpenIDProviderMetadata:
+    """
+    Wrapper around OpenID Provider Metadata values
+    """
+
+    def __init__(self, issuer: str):
+        response = requests.get(urljoin(issuer, "/.well-known/openid-configuration"))
+        response.raise_for_status()
+
+        configuration = response.json()
+
+        self.issuer = issuer
+        self.introspection_endpoint: str = configuration["introspection_endpoint"]
+        self.jwks_uri: str = configuration["jwks_uri"]
+        self.id_token_signing_alg_values_supported: list[str] = configuration[
+            "id_token_signing_alg_values_supported"
+        ]
+
+    def jwks(self) -> JWKSet:
+        """
+        Signing keys used to validate signatures from the OpenID Provider
+        """
+        response = requests.get(self.jwks_uri)
+        response.raise_for_status()
+
+        return JWKSet.from_json(response.text)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Famedly
+# Copyright (C) 2024 Famedly
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,56 +15,60 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from twisted.trial import unittest
-from . import get_auth_provider, get_token
+from . import get_auth_provider, get_jwt_token
 
 
-class SimpleTestCase(unittest.TestCase):
+class JWTTests(unittest.TestCase):
     async def test_wrong_login_type(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice")
-        result = await auth_provider.check_auth("alice", "m.password", {"token": token})
+        token = get_jwt_token("alice")
+        result = await auth_provider.check_jwt_auth(
+            "alice", "m.password", {"token": token}
+        )
         self.assertEqual(result, None)
 
     async def test_missing_token(self):
         auth_provider = get_auth_provider()
-        result = await auth_provider.check_auth("alice", "com.famedly.login.token", {})
+        result = await auth_provider.check_jwt_auth(
+            "alice", "com.famedly.login.token", {}
+        )
         self.assertEqual(result, None)
 
     async def test_invalid_token(self):
         auth_provider = get_auth_provider()
-        result = await auth_provider.check_auth(
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": "invalid"}
         )
         self.assertEqual(result, None)
 
     async def test_token_wrong_secret(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice", secret="wrong secret")
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", secret="wrong secret")
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
 
     async def test_token_wrong_alg(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice", algorithm="HS256")
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", algorithm="HS256")
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
 
     async def test_token_expired(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice", exp_in=-60)
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", exp_in=-60)
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
 
     async def test_token_no_expiry(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice", exp_in=-1)
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", exp_in=-1)
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
@@ -72,73 +76,77 @@ class SimpleTestCase(unittest.TestCase):
     async def test_token_no_expiry_with_config(self):
         auth_provider = get_auth_provider(
             config={
-                "secret": "foxies",
-                "require_expiry": False,
+                "jwt": {
+                    "secret": "foxies",
+                    "require_expiry": False,
+                }
             }
         )
-        token = get_token("alice", exp_in=-1)
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", exp_in=-1)
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
-        self.assertEqual(result[0], "@alice:example.org")
+        self.assertEqual(result[0], "@alice:example.test")
 
     async def test_valid_login(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice")
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice")
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
-        self.assertEqual(result[0], "@alice:example.org")
+        self.assertEqual(result[0], "@alice:example.test")
 
     async def test_valid_login_no_register(self):
         auth_provider = get_auth_provider(user_exists=False)
-        token = get_token("alice")
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice")
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
 
     async def test_chatbox_login(self):
         auth_provider = get_auth_provider()
-        token = get_token(
+        token = get_jwt_token(
             "alice_5833eb34-7dbf-44a7-90cf-868c50922c06", claims={"type": "chatbox"}
         )
-        result = await auth_provider.check_auth(
+        result = await auth_provider.check_jwt_auth(
             "alice_5833eb34-7dbf-44a7-90cf-868c50922c06",
             "com.famedly.login.token",
             {"token": token},
         )
         self.assertEqual(
-            result[0], "@alice_5833eb34-7dbf-44a7-90cf-868c50922c06:example.org"
+            result[0], "@alice_5833eb34-7dbf-44a7-90cf-868c50922c06:example.test"
         )
 
     async def test_chatbox_login_invalid_format(self):
         auth_provider = get_auth_provider(user_exists=False)
-        token = get_token("alice", claims={"type": "chatbox"})
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", claims={"type": "chatbox"})
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
         self.assertEqual(result, None)
 
     async def test_valid_login_with_register(self):
         config = {
-            "secret": "foxies",
-            "allow_registration": True,
+            "jwt": {
+                "secret": "foxies",
+                "allow_registration": True,
+            },
         }
         auth_provider = get_auth_provider(config=config, user_exists=False)
-        token = get_token("alice")
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice")
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
-        self.assertEqual(result[0], "@alice:example.org")
+        self.assertEqual(result[0], "@alice:example.test")
 
     async def test_valid_login_with_admin(self):
         auth_provider = get_auth_provider()
-        token = get_token("alice", admin=True)
-        result = await auth_provider.check_auth(
+        token = get_jwt_token("alice", admin=True)
+        result = await auth_provider.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
-        self.assertEqual(result[0], "@alice:example.org")
+        self.assertEqual(result[0], "@alice:example.test")
         self.assertIdentical(
-            await auth_provider.api.is_user_admin("@alice:example.org"), True
+            await auth_provider.api.is_user_admin("@alice:example.test"), True
         )

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2024 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from twisted.trial import unittest
+from . import get_auth_provider, get_oidc_login, mock_idp_get, mock_idp_post
+from unittest import mock
+
+
+class OIDCTests(unittest.TestCase):
+    async def test_wrong_login_type(self):
+        auth_provider = get_auth_provider()
+        result = await auth_provider.check_oidc_auth(
+            "alice", "m.password", get_oidc_login("alice")
+        )
+        self.assertEqual(result, None)
+
+    async def test_missing_token(self):
+        auth_provider = get_auth_provider()
+        result = await auth_provider.check_oidc_auth(
+            "alice", "com.famedly.login.token,oidc", {}
+        )
+        self.assertEqual(result, None)
+
+    @mock.patch("requests.get", side_effect=mock_idp_get)
+    @mock.patch("requests.post", side_effect=mock_idp_post)
+    async def test_invalid_token(self, *args):
+        auth_provider = get_auth_provider()
+        result = await auth_provider.check_oidc_auth(
+            "alice", "com.famedly.login.token.oidc", {"token": "invalid"}
+        )
+        self.assertEqual(result, None)
+
+    @mock.patch("requests.get", side_effect=mock_idp_get)
+    @mock.patch("requests.post", side_effect=mock_idp_post)
+    async def test_valid_login(self, *args):
+        auth_provider = get_auth_provider()
+        result = await auth_provider.check_oidc_auth(
+            "alice", "com.famedly.login.token.oidc", get_oidc_login("alice")
+        )
+        self.assertEqual(result[0], "@alice:example.test")
+
+    @mock.patch("requests.get", side_effect=mock_idp_get)
+    @mock.patch("requests.post", side_effect=mock_idp_post)
+    async def test_valid_login_no_register(self, *args):
+        auth_provider = get_auth_provider(user_exists=False)
+        result = await auth_provider.check_oidc_auth(
+            "alice", "com.famedly.login.token.oidc", get_oidc_login("alice")
+        )
+        self.assertEqual(result, None)
+
+    @mock.patch("requests.get", side_effect=mock_idp_get)
+    @mock.patch("requests.post", side_effect=mock_idp_post)
+    async def test_valid_login_with_register(self, *args):
+        config = {
+            "oidc": {
+                "issuer": "https://idp.example.test",
+                "client_id": "1111@project",
+                "client_secret": "2222@project",
+                "project_id": "231872387283",
+                "organization_id": "2283783782778",
+                "allow_registration": True,
+            },
+        }
+        auth_provider = get_auth_provider(config=config, user_exists=False)
+        result = await auth_provider.check_oidc_auth(
+            "alice", "com.famedly.login.token.oidc", get_oidc_login("alice")
+        )
+        self.assertEqual(result[0], "@alice:example.test")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -61,7 +61,7 @@ class SimpleTestCase(unittest.TestCase):
         )
         self.assertEqual(result, None)
 
-    async def test_token_no_expiracy(self):
+    async def test_token_no_expiry(self):
         auth_provider = get_auth_provider()
         token = get_token("alice", exp_in=-1)
         result = await auth_provider.check_auth(
@@ -69,11 +69,11 @@ class SimpleTestCase(unittest.TestCase):
         )
         self.assertEqual(result, None)
 
-    async def test_token_no_expiracy_with_config(self):
+    async def test_token_no_expiry_with_config(self):
         auth_provider = get_auth_provider(
             config={
                 "secret": "foxies",
-                "require_expiracy": False,
+                "require_expiry": False,
             }
         )
         token = get_token("alice", exp_in=-1)


### PR DESCRIPTION
Closes #26 

Still a bunch of TODOs left, mostly around testing and documentation.
Naming is a bit tricky, since it can't really be called an "OAuth2 login flow", and it can't be called an "OIDC login flow", but I guess it's closer to the latter since we rely on a lot of parts of the OpenID Connect Discovery spec.

## Main differences from the proposed implementation
- Config options are named differently, `redirect-url` is not present (as it's currently not used anywhere), and the OpenID Provider Configuration URL doesn't need to be specified (as it can be derived from the issuer URL)
- `com.famedly.login.token.oauth` -> `com.famedly.login.token.oidc`
- `/_famedly/login/com.famedly.login.oauth` -> `/_famedly/login/com.famedly.login.token.oidc`