### PR TITLE
feat: Add jwks fetch from idp

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ If `notify_on_registration` is set then `notify_on_registration.url` will be cal
 | `required_scopes`  | Space separated string or a list of strings (optional)    |
 | `jwk_set`          | [JWKSet](https://datatracker.ietf.org/doc/html/rfc7517#section-5) or [JWK](https://datatracker.ietf.org/doc/html/rfc7517#section-4) (optional) |
 | `jwk_file`         | String (optional)                                         |
+| `jwks_endpoint`    | String (optional)                                         |
 
-Either `jwk_set` or `jwk_file` must be specified.
+Either `jwk_set` or `jwk_file` or `jwks_endpoint` must be specified.
 
 
 ### IntrospectionValidationConfig

--- a/synapse_token_authenticator/config.py
+++ b/synapse_token_authenticator/config.py
@@ -70,6 +70,7 @@ class TokenAuthenticatorConfig:
                 required_scopes: str | List[str] | None = None
                 jwk_set: JWKSet | JWK | None = None
                 jwk_file: str | None = None
+                jwks_endpoint: str | None = None
 
                 def __post_init__(self):
                     if not isinstance(self.validator, Exist):
@@ -82,7 +83,7 @@ class TokenAuthenticatorConfig:
                     elif self.jwk_file:
                         with open(self.jwk_file) as f:
                             self.jwk_set = JWK.from_pem(f.read())
-                    else:
+                    elif not self.jwks_endpoint:
                         raise Exception("No JWK")
 
             @dataclass

--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -22,6 +22,7 @@ from urllib.parse import urljoin
 
 import synapse
 from jwcrypto import jwk, jwt
+from jwcrypto.jwk import JWKSet
 from jwcrypto.common import JWException, json_decode
 from synapse.api.errors import HttpResponseException
 from synapse.module_api import ModuleApi
@@ -317,6 +318,11 @@ class TokenAuthenticator:
             check_claims: dict = {}
             if config.jwt_validation.require_expiry:
                 check_claims["exp"] = None
+            if config.jwt_validation.jwks_endpoint:
+                jwks_json = await client.get_raw(
+                    config.jwt_validation.jwks_endpoint,
+                )
+                config.jwt_validation.jwk_set = JWKSet.from_json(jwks_json)
             try:
                 token = jwt.JWT(
                     jwt=token,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -135,17 +135,24 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         return conf
 
 
-def get_jwk(secret="foxies"):
+def get_jwk(secret="foxies", id="123456"):
     return jwk.JWK(
         k=base64.urlsafe_b64encode(secret.encode("utf-8")).decode("utf-8"),
         kty="oct",
+        kid=id,
     )
 
 
 def get_jwt_token(
-    username, exp_in=None, secret="foxies", algorithm="HS512", admin=None, claims=None
+    username,
+    exp_in=None,
+    secret="foxies",
+    algorithm="HS512",
+    admin=None,
+    claims=None,
+    id="123456",
 ):
-    key = get_jwk(secret)
+    key = get_jwk(secret, id)
     if claims is None:
         claims = {}
     claims["sub"] = username
@@ -157,7 +164,7 @@ def get_jwt_token(
             claims["exp"] = int(time.time()) + 120
         else:
             claims["exp"] = int(time.time()) + exp_in
-    token = jwt.JWT(header={"alg": algorithm}, claims=claims)
+    token = jwt.JWT(header={"alg": algorithm, "kid": id}, claims=claims)
     token.make_signed_token(key)
     return token.serialize()
 


### PR DESCRIPTION
Closes: #46 

This implementation is not caching the jwks. If we expect many request to be validated we should add a cache to it.