### PR TITLE
Remove username check and add localpart lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2025-03-11
+
+### Features
+
+- Remove username check and add localpart lowercase
+
 ## [0.10.0] - 2025-03-07
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ or
 | `enc_jwks_endpoint`        | String (optional) (defaults to `/.well-known/jwks.json`)                  |
 | `displayname_path`         | [`Path`](#path) (optional)                                                |
 | `localpart_path`           | [`Path`](#path) (optional)                                                |
+| `lowercase_localpart`      | Bool (defaults to `false`)                                                |
 
 Either `jwk_set` or `jwk_file` or `jwks_endpoint` must be specified and either `enc_jwk` or `enc_jwk_file` must be specified.
 
@@ -381,6 +382,8 @@ Either `jwk_set` or `jwk_file` or `jwks_endpoint` must be specified and either `
 `iss` is the expected issuer of the token and this will be checked against the claim `iss` of the token.
 
 `enc_jwks_endpoint` is the endpoint where the synapse token authenticator will publish the public keys for encrypting the JWEs. The full path of the endpoint will be `https://<homeserver>/<enc_jwks_endpoint>`. This endpoint will contain only a [JWKSet](https://datatracker.ietf.org/doc/html/rfc7517#section-5) in json format and the JWKSet will have only one key in it.
+
+If `lowercase_localpart` is set to `true` the flow will transform all localparts to lowercase
 
 ## Usage
 
@@ -436,11 +439,13 @@ Next, the client needs to use these tokens and construct a payload to the login 
   "type": "com.famedly.login.token.epa",
   "identifier": {
     "type": "m.id.user",
-    "user": "alice" // The user's localpart, extracted from the localpart in the ID token returned by the IDP
+    "user": "NOT_USED" // The user field will be ignored by this flow
   },
   "token": "<jwe here>" // The access token returned by the IDP
 }
 ```
+
+For this flow the `user` field will be ignored.
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # TODO: Remove this dependency when we can
   "Twisted==24.7.0",
 ]
-version = "0.10.0"
+version = "0.11.0"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-token-authenticator"

--- a/synapse_token_authenticator/config.py
+++ b/synapse_token_authenticator/config.py
@@ -172,6 +172,7 @@ class TokenAuthenticatorConfig:
                 jwks_endpoint: str | None = None
                 localpart_path: str | None = None
                 displayname_path: str | None = None
+                lowercase_localpart: bool = False
 
                 def __post_init__(self):
                     if not isinstance(self.validator, Exist):

--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -619,7 +619,7 @@ class TokenAuthenticator:
         return (fully_qualified_uid, None)
 
     async def check_epa(
-        self, username: str, login_type: str, login_dict: "synapse.module_api.JsonDict"
+        self, _username: str, login_type: str, login_dict: "synapse.module_api.JsonDict"
     ) -> Optional[
         tuple[
             str,
@@ -696,9 +696,9 @@ class TokenAuthenticator:
         if not localpart:
             logger.info("Missing localpart")
             return None
-        if username != localpart:
-            logger.info("The username doesn't match the localpart")
-            return None
+
+        if config.lowercase_localpart:
+            localpart = localpart.lower()
 
         if not config.validator.validate(jwt_claims):
             logger.info("Token claims validation failed")


### PR DESCRIPTION
For the epa to work we need

 - STA must ignore the "identifier" that is sent along with the token
 - tim-proxy must lowercase the contents of sub

This PR changes the flow to ignore the "identifier" and also adds a configuration to transform the localpart to lowercase