### PR TITLE
refactor: Add more logs

### DIFF
--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -601,6 +601,7 @@ class TokenAuthenticator:
                 len(external_ids) > 0
                 and (auth_provider, external_id) not in external_ids
             ):
+                logger.info("User didn't pass on the external id check")
                 logger.debug(
                     f"The external_id '{external_id}' and auth_provider '{auth_provider}' don't match any of the user's stored external ids"
                 )


### PR DESCRIPTION
While testing I was missing this log to know why the login was failing. Since we usually run the modules with info level I added one more log to help tell what's wrong. I'm not just changing the level of the bellow log because it contains the user external id