### PR TITLE
release: v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2026-04-09
+
+### Miscellaneous Tasks
+
+- chore: remove duplicated twisted dependency in pyproject.toml (#80) (FrenchGithubUser)
+- chore: Remove hatch scripts and replace with built-in hatch utilities (#84) (Jason Little)
+- chore: First re-formatting run (#84) (Jason Little)
+- chore: pin jwcrypto to 1.5.6 or lower temporarily (#84) (Jason Little)
+- add to .gitignore for .idea based IDE's (#83)
+
+### Bug Fixes
+
+- fix: prevent early return in PathList lookup when intermediate path fails (#81) (Niklas Zender)
+
 ## [0.13.0] - 2026-03-26
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -26,7 +27,7 @@ dependencies = [
   "jwcrypto<=1.5.6",
   "twisted",
 ]
-version = "0.13.0"
+version = "0.14.0"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-token-authenticator"

--- a/synapse_token_authenticator/token_authenticator.py
+++ b/synapse_token_authenticator/token_authenticator.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 class TokenAuthenticator:
-    __version__ = "0.13.0"
+    __version__ = "0.14.0"
 
     def __init__(self, config: dict, account_handler: ModuleApi):
         self.api = account_handler


### PR DESCRIPTION
## [0.14.0] - 2026-04-09

### Miscellaneous Tasks

- chore: remove duplicated twisted dependency in pyproject.toml (#80) (FrenchGithubUser)
- chore: Remove hatch scripts and replace with built-in hatch utilities (#84) (Jason Little)
- chore: First re-formatting run (#84) (Jason Little)
- chore: pin jwcrypto to 1.5.6 or lower temporarily (#84) (Jason Little)
- add to .gitignore for .idea based IDE's (#83)

### Bug Fixes

- fix: prevent early return in PathList lookup when intermediate path fails (#81) (Niklas Zender)
