### PR TITLE
dep: remove pin on jwcrypto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "jwcrypto<=1.5.6",
+  "jwcrypto",
   "twisted",
 ]
 version = "0.13.1"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,9 @@ from tests.test_utils import FakeResponse as Response
 admins = {}
 logger = logging.getLogger(__name__)
 ENC_JWK = jwk.JWK.generate(kty="RSA", size=2048)
+# secrets for token generation need to be 64 chars long, as it needs to have 512 bits
+# since HS512 is used by default. The word 'jwcrypto' is 8 letters long. Perfect.
+_DEFAULT_TOKEN_SECRET = "jwcrypto" * 8
 
 
 class ModuleApiTestCase(synapsetest.HomeserverTestCase):
@@ -110,7 +113,7 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
                 {
                     "module": "synapse_token_authenticator.TokenAuthenticator",
                     "config": {
-                        "jwt": {"secret": "foxies"},
+                        "jwt": {"secret": _DEFAULT_TOKEN_SECRET},
                         "oidc": {
                             "issuer": "https://idp.example.test",
                             "client_id": "1111@project",
@@ -146,7 +149,7 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         return conf
 
 
-def get_jwk(secret="foxies", id="123456") -> jwk.JWK:
+def get_jwk(secret=_DEFAULT_TOKEN_SECRET, id="123456") -> jwk.JWK:
     return jwk.JWK(
         k=base64.urlsafe_b64encode(secret.encode("utf-8")).decode("utf-8"),
         kty="oct",
@@ -161,7 +164,7 @@ def get_enc_jwk() -> jwk.JWK:
 def get_jwt_token(
     username,
     exp_in=None,
-    secret="foxies",
+    secret=_DEFAULT_TOKEN_SECRET,
     algorithm="HS512",
     admin=None,
     claims=None,
@@ -192,7 +195,7 @@ def get_jwt_token(
 def get_jwe_token(
     username,
     exp_in=None,
-    secret="foxies",
+    secret=_DEFAULT_TOKEN_SECRET,
     algorithm="HS512",
     admin=None,
     claims=None,

--- a/tests/test_epa.py
+++ b/tests/test_epa.py
@@ -52,9 +52,9 @@ class CustomFlowTests(ModuleApiTestCase):
         self.assertEqual(result, None)
 
     async def test_token_wrong_secret(self):
-        token = get_jwe_token(
-            "alice", secret="wrong secret", claims=get_default_claims()
-        )
+        # The secret needs to be 64 bytes, so pad it and bulk copy it. 16 * 4 = 64
+        secret = "wrong secret1234" * 4
+        token = get_jwe_token("alice", secret=secret, claims=get_default_claims())
         result = await self.hs.mockmod.check_epa(
             "alice", "com.famedly.login.token.epa", {"token": token}
         )

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 import tests.unittest as synapsetest
 
-from . import ModuleApiTestCase, get_jwt_token
+from . import _DEFAULT_TOKEN_SECRET, ModuleApiTestCase, get_jwt_token
 
 
 class JWTTests(ModuleApiTestCase):
@@ -41,7 +41,9 @@ class JWTTests(ModuleApiTestCase):
         self.assertEqual(result, None)
 
     async def test_token_wrong_secret(self):
-        token = get_jwt_token("alice", secret="wrong secret")
+        # The secret needs to be 64 bytes, so pad it and bulk copy it. 16 * 4 = 64
+        secret = "wrong secret1234" * 4
+        token = get_jwt_token("alice", secret=secret)
         result = await self.hs.mockmod.check_jwt_auth(
             "alice", "com.famedly.login.token", {"token": token}
         )
@@ -75,7 +77,7 @@ class JWTTests(ModuleApiTestCase):
                     "module": "synapse_token_authenticator.TokenAuthenticator",
                     "config": {
                         "jwt": {
-                            "secret": "foxies",
+                            "secret": _DEFAULT_TOKEN_SECRET,
                             "require_expiry": False,
                         }
                     },
@@ -134,7 +136,7 @@ class JWTTests(ModuleApiTestCase):
                     "module": "synapse_token_authenticator.TokenAuthenticator",
                     "config": {
                         "jwt": {
-                            "secret": "foxies",
+                            "secret": _DEFAULT_TOKEN_SECRET,
                             "allow_registration": True,
                         },
                     },

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -57,7 +57,9 @@ class CustomFlowTests(ModuleApiTestCase):
         self.assertEqual(result, None)
 
     async def test_token_wrong_secret(self):
-        token = get_jwt_token("aliceid", secret="wrong secret", claims=default_claims)
+        # The secret needs to be 64 bytes, so pad it and bulk copy it. 16 * 4 = 64
+        secret = "wrong secret1234" * 4
+        token = get_jwt_token("aliceid", secret=secret, claims=default_claims)
         result = await self.hs.mockmod.check_oauth(
             "alice", "com.famedly.login.token.oauth", {"token": token}
         )


### PR DESCRIPTION
[SYN-44](https://famedly.atlassian.net/browse/SYN-44)

> In https://github.com/famedly/synapse-token-authenticator/pull/84,  the jwcrypto module got bounded to 1.5.6 which is lower than the [most current version](https://github.com/latchset/jwcrypto/releases/tag/v1.5.7)(1.5.7). This was due to work in that jwcrypto version that[ hardened the length of the token](https://github.com/latchset/jwcrypto/pull/369) to a specific value. This interfered with the testing of the Synapse token authenticator, as it creates test token with junk data that do not meet this criteria. This was manifesting as a series of errors that reported:<br>
`jwcrypto.common.InvalidJWEKeyLength: Expected key of length 512, got 48` <br>
> It is currently unknown if this will affect production or only the testing environment. This needs to be checked for/asked about with the relevant parties.

The algorithm tested against is `HS512` so I assume that is where the 512 bit requirement comes from. 512 bits * 8bit_per_byte = 64 bytes. That sounds manageable.

[SYN-44]: https://famedly.atlassian.net/browse/SYN-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ